### PR TITLE
Translation to Spanish for the 0.18 version.

### DIFF
--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -6,8 +6,8 @@
     "configure-translations": "Configurar traducciones",
     "configure-dicts": "Configurar diccionarios",
     "show-parallel-translations": "Comparar traducciones",
-    "compare": "Compare",
-    "context": "Context"
+    "compare": "Comparar",
+    "context": "Contexto"
   },
   "menu": {
     "book": "Libro",
@@ -17,11 +17,11 @@
     "export": "Exportar a un documento de texto",
     "show-module-info": "Mostrar información del módulo",
     "fullscreen": "Cambiar a modo de pantalla completa",
-    "exit-fullscreen": "Exit full screen mode",
-    "text-size": "Adjust verse font size",
-    "text-size-decrease": "Decrease current font size",
-    "text-size-reset": "Reset font size to default",
-    "text-size-increase": "Increase current font size"
+    "exit-fullscreen": "Salir del modo a pantalla completa",
+    "text-size": "Ajustar tamaño del texto",
+    "text-size-decrease": "Disminuir el tamaño de la fuente ",
+    "text-size-reset": "Restablecer el tamaño de la fuente",
+    "text-size-increase": "Aumentar el tamaño de la fuente"
   },
   "search-menu": {
     "search": "Buscar",
@@ -48,7 +48,7 @@
     "translations": "Traducciones",
     "removal": "Quitar",
     "module-feature-filter": "Filtrar características",
-    "repo-selection-info-text": "Ezra Bible App funciona con {{module_type}} dados por <a class='external' href='http://www.crosswire.org/sword'>the SWORD project</a> y la <a class='external' href='http://www.crosswire.org'>CrossWire Bible Society</a>.<br/><br/>Debajo usted puede ver la lista de repositorios de SWORD publicados por CrossWire. Un repositorio es un espacio de almacenamiento en Internet que contiene un grupo de {{module_type}}. Al lado de cada repositorio, usted verá el número totar de {{module_type}} disponibles desde ese repositorio.<br/><br/>Para instalar un módulo, selecione al menos un repositorio de la lista. El repositorio de <i>CrossWire</i> y el de <i>eBible.org</i> son un buen lugar para comenzar.",
+    "repo-selection-info-text": "Ezra Bible App funciona con {{module_type}} dados por <a class='external' href='http://www.crosswire.org/sword'>the SWORD project</a> y la <a class='external' href='http://www.crosswire.org'>CrossWire Bible Society</a>.<br/><br/>Debajo usted puede ver la lista de repositorios de SWORD publicados por CrossWire. Un repositorio es un espacio de almacenamiento en Internet que contiene un grupo de {{module_type}}. Al lado de cada repositorio, usted verá el número total de {{module_type}} disponibles desde ese repositorio.<br/><br/>Para instalar un módulo, selecione al menos un repositorio de la lista. El repositorio de <i>CrossWire</i> y el de <i>eBible.org</i> son un buen lugar para comenzar.",
     "more-repo-information-needed": "¿Usted necesita más información sobre estos repositorios?<br/>Consulte <a class='external' href='https://wiki.crosswire.org/Official_and_Affiliated_Module_Repositories'>CrossWire Wiki</a> (disponible en inglés).",
     "click-to-show-detailed-module-info": "Pulse sobre el código del módulo (el enlace después del nombre del módulo) para mostrar información detallada.",
     "updating-repository-data": "Actualizando datos de repositorio! Esto tomará unos segundos ...",
@@ -88,12 +88,12 @@
     "sword-module-details": "Detalles del módulo SWORD",
     "sword-module-info": "Información módulo SWORD",
     "sword-unlock-info": "Información de desbloqueo de SWORD",
-    "application-version": "Application version",
+    "application-version": "Versión de la aplicación",
     "git-commit": "Git commit",
     "sword-version": "Versión de SWORD",
     "chromium-version": "Versión de Chromium",
-    "database-path": "Database path",
-    "config-file-path": "Configuration path",
+    "database-path": "Ruta al directorio de base de datos",
+    "config-file-path": "Ruta del directorio de configuración",
     "module-name": "Nombre",
     "module-version": "Versión",
     "module-language": "Idioma",
@@ -129,10 +129,10 @@
     "module-unlock-failed": "falló (problema de desbloqueo).",
     "installing-strongs": "Instalando <i>Strong's dictionaries</i>",
     "applying-migrations": "Migrando la base de datos a una nueva versión",
-    "new-note-hint": "Click to add a note",
-    "developers": "Developers",
-    "translators": "Translators",
-    "versions-and-paths": "Versions and paths"
+    "new-note-hint": "Presione para añadir una nota",
+    "developers": "Desarrolladores",
+    "translators": "Traductores",
+    "versions-and-paths": "Versiones y rutas"
   },
   "help": {
     "help-text-no-tags-book-opened": "Para comenzar trabajando con las etiquetas, debe crear su primera etiqueta pulsando en el botón <i>Nueva&nbsp;etiqueta</i>.<br/><br/>Después usted podrá seleccionar los textos de La Biblia que desee, para ello pulse sobre un verso o arrastre para seleccionar varios versos y asigne los a la etiqueta que acaba de crear.",
@@ -159,7 +159,7 @@
     "tag-filter": "Filtro: ",
     "recently-used-filter": "Filtrar usadas recientemente",
     "assign-tag": "Asignar etiqueta",
-    "change-tags": "Change tags",
+    "change-tags": "Cambiar etiquetas",
     "delete-tag-permanently": "Eliminar esta etiqueta permanentemente",
     "none-selected": "Nada",
     "rename-tag": "Renombrar etiqueta",
@@ -167,8 +167,8 @@
     "stats-used": "usado",
     "stats-total": "total",
     "only-currentbook-tagged-verses": "Solo libro actual",
-    "most-frequently-used": "Most frequently used",
-    "less-frequently-used": "Less frequently used"
+    "most-frequently-used": "Más usadas",
+    "less-frequently-used": "Menos usadas"
   },
   "bible-browser": {
     "chapter": "Capítulo",
@@ -181,7 +181,7 @@
     "searching-for": "Buscando",
     "search-result-header": "Resultados para ",
     "no-search-results": "No se encontraron resultados para la consulta ",
-    "module-search-cancelled": "Module search cancelled when searching for ",
+    "module-search-cancelled": "La busqueda de módulos fue cancelada cuando se buscaba ",
     "load-verse-context": "Cargar el contexto del verso",
     "tag-hint": "Pulse para mostrar todos los versos con esta etiqueta",
     "show-search-results": "Mostrar resultados de la búsqueda",
@@ -199,23 +199,23 @@
     "show-xrefs": "Mostrar referencias cruzadas",
     "show-footnotes": "Mostrar notas al pie",
     "show-dictionary": "Mostrar diccionario",
-    "show-book-chapter-navigation": "Show book/chapter navigation",
+    "show-book-chapter-navigation": "Mostrar la navegación por Libro/Capítulo",
     "show-header-navigation": "Mostrar navegación por encabezado",
     "open-verse-lists-in-new-tab": "Abrir la lista de versículos en una nueva pestaña",
-    "show-notes-tags-indicators": "Show notes/tags indicators",
+    "show-notes-tags-indicators": "Mostrar indicadores de notas/etiquetas",
     "show-tags": "Mostrar etiquetas",
     "show-notes": "Mostrar notas",
     "limit-notes-display-size": "Limitar el tamaño de las notas",
     "use-tags-column": "Usar columna de etiquetas",
     "use-night-mode": "Modo Noche",
-    "keep-screen-on": "Keep screen on",
+    "keep-screen-on": "Mantener la pantalla activa",
     "tag-statistics": "Estadística de etiquetas",
     "comparing-translations-for": "Comparar traducciones de",
     "strongs-number-not-valid": "Este número Strongs no es válido!",
     "open-new-tab": "Abrir nueva pestaña",
     "open-verselist-in-new-tab": "Abrir la lista de versos en una nueva pestaña",
     "footnote-character": "n",
-    "adjust-font-size-tags-notes": "Adjust tags & notes font size"
+    "adjust-font-size-tags-notes": "Ajustar el tamaño de fuente de notas y etiquetas"
   },
   "dictionary-info-box": {
     "greek-dict": "Diccionario Griego",
@@ -227,11 +227,11 @@
     "related-strongs": "Números Strongs relacionados"
   },
   "cordova" : {
-    "welcome-to-ezra-bible-app": "Welcome to Ezra Bible App!",
-    "storage-justification": "Ezra Bible App needs access to the device storage area to save SWORD modules and store its database.<br><br>After pressing the button below, you will be asked to allow Ezra Bible App to access files on your device.",
-    "enable-storage-access": "Enable access to device storage",
-    "storage-permission-denied": "You decided to deny storage access.<br>You can change this by pressing the button below!",
-    "permanent-permission-decision-part1": "Previously, you decided to permanently deny storage access!<br><br>You can only revert that decision in the permission settings in the Android system configuration.",
-    "permanent-permission-decision-part2": "If you do not change the permission settings,<br>Ezra Bible App will <span style='text-decoration: underline'>not start up successfully</span>."
+    "welcome-to-ezra-bible-app": "Bienvenido a Ezra Bible App!",
+    "storage-justification": "Ezra Bible App necesita permiso para acceder al almacenamiento del dispositivo para guardar módulos SWORD y su base de datos.<br><br>Después de presionar el botón que aparece debajo, se le preguntará si desea permitir a Ezra Bible App tener acceso a los archivos en su dispositivo.",
+    "enable-storage-access": "Permitir acceso al almacenamiento del dispositivo",
+    "storage-permission-denied": "Usted a decidido denegar el acceso al almacenamiento.<br>Puede cambiarlo presionando el botón de abajo!",
+    "permanent-permission-decision-part1": "Previamente usted decidió denegar permanentemente el acceso al almacenamiento!<br><br>Sólo puede revertir esa decisión en la sección de permisos de aplicaciones en la configuración del sistema.",
+    "permanent-permission-decision-part2": "Si no cambia la configuración de permisos,<br>Ezra Bible App <span style='text-decoration: underline'> no podrá iniciar correctamente</span>."
   }
 }


### PR DESCRIPTION
I leave unaltered the Ezra Bible App brand on every string because it will be funny to translate it into "Aplicación Bíblica Esdras".
Git commit string was also unaltered because Spanish doesn't have a proper way to translate it and keep the original meaning.
@Rodolinux could you please check if everything is well translated and correct possibles mistakes?